### PR TITLE
カードコンポーネントを作り、ブログ記事に流用

### DIFF
--- a/app/views/pages/_blog.html.erb
+++ b/app/views/pages/_blog.html.erb
@@ -1,17 +1,19 @@
 <section id="blog" class="py-16 md:py-24">
-  <h2 class="text-3xl font-bold tracking-tight text-center mb-12">最新のブログ記事</h2>
+  <h2 class="text-3xl font-bold text-center mb-12">最新のブログ記事</h2>
+
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-    <% [
-      ["2023年10月26日", "Rails 7のHotwire入門", "Hotwireを使ってインタラクティブなUIを簡単に実装する方法を紹介します。"],
-      ["2023年10月15日", "daisyUIでデザインを高速化", "daisyUIのコンポーネントを活用してUIを素早く構築するコツ。"],
-      ["2023年9月28日", "ポートフォリオサイト制作の裏側", "このサイトの技術スタックと設計思想を解説します。"]
-    ].each do |date, title, summary| %>
-      <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-md">
-        <p class="text-sm text-gray-500 mb-2"><%= date %></p>
-        <h3 class="text-xl font-bold mb-3"><%= title %></h3>
-        <p class="text-gray-700 dark:text-gray-300 mb-4"><%= summary %></p>
-        <a href="#" class="text-primary font-bold hover:underline">記事を読む →</a>
-      </div>
+    <% @articles = [
+      { title: "Rails 8で始めるAPI開発", summary: "Rails 8の新機能を使ってAPIを設計します。", image: "sample1.jpg", link: "#" },
+      { title: "daisyUIでUIを作る", summary: "Tailwindをベースに効率よくデザインを組む方法。", image: "sample2.jpg", link: "#" },
+      { title: "DockerでRails開発環境構築", summary: "コンテナ開発を楽にするDockerfileの作り方。", image: "sample3.jpg", link: "#" }
+    ] %>
+
+    <% @articles.each do |article| %>
+      <%= render "shared/card",
+          title: article[:title],
+          summary: article[:summary],
+          image: nil,
+          link: article[:link] %>
     <% end %>
   </div>
 </section>

--- a/app/views/shared/_card.html.erb
+++ b/app/views/shared/_card.html.erb
@@ -1,0 +1,18 @@
+<div class="card bg-base-100 shadow-md hover:shadow-xl transition-transform hover:scale-105">
+  <% if image.present? %>
+    <%= image_tag image, alt: title, class: "w-full aspect-video object-cover" %>
+  <% end %>
+  <div class="card-body">
+    <h3 class="card-title text-lg font-bold"><%= title %></h3>
+    <p class="text-gray-600 dark:text-gray-300"><%= summary %></p>
+    <% if link.present? %>
+      <div class="card-actions justify-end">
+        <%= link_to "続きを読む →", link, class: "text-primary font-bold hover:underline" %>
+      </div>
+    <% end %>
+  </div>
+</div>
+
+<%# 
+ 使用方法：
+ render "shared/card", title: "記事タイトル", summary: "概要文", image: "sample.jpg", link: "#" %>


### PR DESCRIPTION
## 概要
このPRでは、トップページで使うカードコンポーネントを追加します。  

対応Issue: #8 

---

## 変更内容
- ` app/views/shared/_card.html.erb `を追加
- ブログ記事で使うようにして、表示を確認
---

## 確認項目
- [ ] issueの要件を満たしているか確認していく
- [ ] 命名・インデント・ファイル構成に一貫性がある

---


## 補足
- 後々ポートフォリオでも使う
- スキルセットで使う場合は別コンポーネント（` _skill_item.html.erb `）として準備する
- 
