### PR TITLE
ポートフォリオをサービスクラスに移動させた

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,6 +2,7 @@ require "ostruct"
 
 class PagesController < ApplicationController
   def index
-  @articles = ArticleCache.all.order(published_at: :desc).limit(3)
+    @articles = ArticleCache.all.order(published_at: :desc).limit(3)
+    @projects = PortfolioService.projects
   end
 end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -11,14 +11,6 @@ class StaticPagesController < ApplicationController
   end
 
   def portfolio
-    @projects = [
-      {
-        title: "月めぐるノート",
-        description: "月の満ち欠けと日記を記録できるアプリ。\n日々の振り返りのサイクルを月相と組み合わせてみました。",
-        image: "portfolio/tsukimeguru-note.png",
-        github_url: "https://github.com/okarina-chaan/tsukimeguru_note",
-        site_url: "https://tsukimeguru-note.com"
-      }
-    ]
+    @projects = PortfolioService.projects
   end
 end

--- a/app/services/portfolio_service.rb
+++ b/app/services/portfolio_service.rb
@@ -1,0 +1,13 @@
+class PortfolioService
+  def self.projects
+    [
+      {
+        title: "月めぐるノート",
+        description: "月の満ち欠けと日記を記録できるアプリ。\n日々の振り返りのサイクルを月相と組み合わせてみました。",
+        image: "portfolio/tsukimeguru-note.png",
+        github_url: "https://github.com/okarina-chaan/tsukimeguru_note",
+        site_url: "https://tsukimeguru-note.com"
+      }
+    ]
+  end
+end

--- a/app/views/pages/_portfolio.html.erb
+++ b/app/views/pages/_portfolio.html.erb
@@ -9,22 +9,22 @@
   </h2>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 px-8">
-    <!-- Coming Soon カード -->
-    <div class="card bg-base-100 dark:bg-gray-800 shadow-xl hover:scale-[1.02] transition-transform border border-accent/30">
-      <figure class="bg-gray-200 dark:bg-gray-700">
-        <img src="<%= asset_path('portfolio/coming_soon.png') %>" alt="Coming Soon" class="w-full h-48 object-cover opacity-80" />
-      </figure>
-      <div class="card-body">
-        <h3 class="text-xl font-bold mb-2 text-secondary">Coming Soon...</h3>
-        <p class="text-gray-600 dark:text-gray-300 mb-4">
-          現在、ポートフォリオを準備中です。<br>
-          公開まで今しばらくお待ちください。
-        </p>
-        <div class="card-actions justify-end mt-4">
-          <%= link_to "GitHub", "#", class: "btn btn-outline btn-primary cursor-not-allowed opacity-50" %>
-          <%= link_to "サイトを見る", "#", class: "btn btn-primary cursor-not-allowed opacity-50" %>
+    <% PortfolioService.projects.each do |project| %>
+      <div class="card bg-base-100 dark:bg-gray-800 shadow-xl hover:scale-[1.02] transition-transform border border-accent/30">
+        <figure class="bg-gray-200 dark:bg-gray-700">
+          <%= image_tag project[:image], alt: project[:title], class: "w-full h-48 object-cover" %>
+        </figure>
+        <div class="card-body">
+          <h3 class="text-xl font-bold mb-2 text-secondary"><%= project[:title] %></h3>
+          <p class="text-gray-600 dark:text-gray-300 mb-4">
+            <%= simple_format(project[:description]) %>
+          </p>
+          <div class="card-actions justify-end mt-4">
+            <%= link_to "GitHub", project[:github_url], target: "_blank", rel: "noopener noreferrer", class: "btn btn-outline btn-primary" %>
+            <%= link_to "サイトを見る", project[:site_url], target: "_blank", rel: "noopener noreferrer", class: "btn btn-primary" %>
+          </div>
         </div>
       </div>
-    </div>
+    <% end %>
   </div>
 </section>


### PR DESCRIPTION
## 概要
コントローラにポートフォリオの管理をさせていたので、
サービスクラスに切り出した

対応Issue: なし

---

## 変更内容
- ポートフォリオについてportfolot_serviseとして切り出した
- 以下のページでサービスクラスを参照するように変更した
　　- トップページ
　　- ポートフォリオページ
---

## 確認項目
- [ ] issueの要件を満たしているか確認していく
- [ ] 命名・インデント・ファイル構成に一貫性がある

---


## 補足
- 何かあれば
